### PR TITLE
[MPE-5716] feat: add heightProperty prop for dynamic height adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ And set `androidAdjustResize` to `true`. For example,
 | `alwaysVisible` | `boolean` | `false` | When set to `true` Accessory View will be always visible at the bottom of the screen. Good for sticky `TextInput`'s |
 | `bumperHeight` | `number` | 15 | Bumper height to prevent visual glitches if animation couldn't keep up with the keyboard animation. |
 | `visibleOpacity` | `number` | 1 | Opacity of the Accessory when it is visible. *Note:* Opacity is used for hiding the accessory to prevent render delays. |
+| `heightProperty` | `enum:string` | `height` | Control how the component manages its height. The component listens for children changes and automatically adjusts its height, so `height` is usually sufficient. For use with a multiline, autogrowing `TextInput`, `minHeight` is recommended. Values: `['height', 'minHeight']` |
 | `hiddenOpacity` | `number` | 0 | Opacity of the Accessory when it is hidden. |
 | `hideBorder` | `boolean` | false | Set true if you want to hide top border of the Accessory |
 | `inSafeAreaView` | `boolean` | false | Set true if you want to adapt SafeAreaView on iPhone X |

--- a/src/KeyboardAccessoryView.js
+++ b/src/KeyboardAccessoryView.js
@@ -176,6 +176,7 @@ class KeyboardAccessoryView extends Component {
       visibleOpacity,
       hiddenOpacity,
       hideBorder,
+      heightProperty
       style,
       inSafeAreaView,
       safeAreaBumper,
@@ -190,7 +191,7 @@ class KeyboardAccessoryView extends Component {
     return (
       <View
         style={{
-          height: isKeyboardVisible || alwaysVisible ? visibleHeight : 0
+          [heightProperty]: isKeyboardVisible || alwaysVisible ? visibleHeight : 0
         }}
         pointerEvents="box-none"
       >
@@ -205,7 +206,7 @@ class KeyboardAccessoryView extends Component {
                   ? visibleOpacity
                   : hiddenOpacity,
               bottom: keyboardHeight - bumperHeight - (applySafeArea ? 20 : 0),
-              height:
+              [heightProperty]:
                 accessoryHeight +
                 bumperHeight +
                 (applySafeArea ? (!isKeyboardVisible ? 20 : -10) : 0)
@@ -230,6 +231,7 @@ KeyboardAccessoryView.propTypes = {
   animationConfig: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
   bumperHeight: PropTypes.number,
   visibleOpacity: PropTypes.number,
+  heightProperty: PropTypes.oneOf(["height", "minHeight"]),
   hiddenOpacity: PropTypes.number,
   onKeyboardShowDelay: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
   androidAdjustResize: PropTypes.bool,
@@ -245,6 +247,7 @@ KeyboardAccessoryView.defaultProps = {
   animateOn: "ios",
   bumperHeight: 15,
   visibleOpacity: 1,
+  heightProperty: 'height',
   hiddenOpacity: 0,
   androidAdjustResize: false,
   alwaysVisible: false,


### PR DESCRIPTION
Adds the `heightProperty` parameter to allow have resizable inputs inside the `KeyboardAccesoryView`

This was already [implemented](https://github.com/ardaogulcan/react-native-keyboard-accessory/pull/77/files) in the original repo